### PR TITLE
#163519108 Implement filter by tags when viewing an article

### DIFF
--- a/src/__tests__/components/Article.test.js
+++ b/src/__tests__/components/Article.test.js
@@ -4,10 +4,30 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import Article, { mapStateToProps, mapDispatchToProps } from '../../components/Article/Article';
-import { articleDataDraft } from '../../__mocks__/dummyData';
+import { articleDataDraft, articleData } from '../../__mocks__/dummyData';
 import initialState from '../../redux/initialState.json';
 
 let wrapper;
+const props = {
+  loading: true,
+  singleArticle: articleData,
+  article: articleData,
+  currentUser: {
+    username: 'username',
+  },
+  getArticle: jest.fn().mockImplementation(() => Promise.resolve({ status: 200 })),
+  rateArticle: jest.fn().mockImplementation(() => Promise.resolve({ status: 200 })),
+  onLikeArticle: jest.fn().mockImplementation(() => Promise.resolve({ status: 200 })),
+  onDislikeArticle: jest.fn().mockImplementation(() => Promise.resolve({ status: 200 })),
+  nextPath: jest.fn().mockImplementation(() => Promise.resolve({ status: 200 })),
+  match: {
+    params: {
+      articleSlug: 'article-slug',
+    },
+  },
+  history: { push: jest.fn() },
+  isLoggedIn: true,
+};
 
 const mockStore = configureMockStore([thunk]);
 let store = mockStore(initialState);
@@ -218,6 +238,14 @@ describe('<Article />', () => {
     test('should dislike an article', () => {
       wrapper.find('Article').find('button[data-value="dislike"]').simulate('click');
       expect(wrapper.find('Article').props().nextPath).toBeDefined();
+    });
+
+    test('should call navigateToArticles instance function', () => {
+      wrapper
+        .find('span[className="tagged"]')
+        .at(1)
+        .simulate('click');
+      expect(props.history.push).toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/components/Article.test.js
+++ b/src/__tests__/components/Article.test.js
@@ -10,8 +10,8 @@ import initialState from '../../redux/initialState.json';
 let wrapper;
 const props = {
   loading: true,
-  singleArticle: articleData,
-  article: articleData,
+  singleArticle: articleDataDraft,
+  article: articleDataDraft,
   currentUser: {
     username: 'username',
   },
@@ -26,6 +26,7 @@ const props = {
     },
   },
   history: { push: jest.fn() },
+  navigateToArticles: jest.fn(),
   isLoggedIn: true,
 };
 
@@ -33,11 +34,23 @@ const mockStore = configureMockStore([thunk]);
 let store = mockStore(initialState);
 describe('<Article />', () => {
   beforeEach(() => {
-    wrapper = mount(<Provider store={store}><Article /></Provider>);
+    wrapper = mount(
+      <Provider store={store}>
+        <Article />
+      </Provider>,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   test('should render the <Article />', () => {
-    wrapper = shallow(<Provider store={store}><Article /></Provider>);
+    wrapper = shallow(
+      <Provider store={store}>
+        <Article />
+      </Provider>,
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -50,7 +63,11 @@ describe('<Article />', () => {
       const state = initialState;
       state.article.singleArticle.rated = 1;
       store = mockStore(state);
-      wrapper = mount(<Provider store={store}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store}>
+          <Article />
+        </Provider>,
+      );
       expect(wrapper.find('Article').props().singleArticle.rated).toBe(1);
     });
 
@@ -58,7 +75,11 @@ describe('<Article />', () => {
       const state = initialState;
       state.article.singleArticle.rated = 2;
       store = mockStore(state);
-      wrapper = mount(<Provider store={store}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store}>
+          <Article />
+        </Provider>,
+      );
       expect(wrapper.find('Article').props().singleArticle.rated).toBe(2);
     });
 
@@ -66,7 +87,11 @@ describe('<Article />', () => {
       const state = initialState;
       state.article.singleArticle.rated = 3;
       store = mockStore(state);
-      wrapper = mount(<Provider store={store}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store}>
+          <Article />
+        </Provider>,
+      );
       expect(wrapper.find('Article').props().singleArticle.rated).toBe(3);
     });
 
@@ -74,7 +99,11 @@ describe('<Article />', () => {
       const state = initialState;
       state.article.singleArticle.rated = 4;
       store = mockStore(state);
-      wrapper = mount(<Provider store={store}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store}>
+          <Article />
+        </Provider>,
+      );
       expect(wrapper.find('Article').props().singleArticle.rated).toBe(4);
     });
 
@@ -82,14 +111,22 @@ describe('<Article />', () => {
       const state = initialState;
       state.article.singleArticle.rated = 5;
       store = mockStore(state);
-      wrapper = mount(<Provider store={store}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store}>
+          <Article />
+        </Provider>,
+      );
       expect(wrapper.find('Article').props().singleArticle.rated).toBe(5);
     });
   });
 
   describe('when clicking on rateArticle', () => {
     beforeEach(() => {
-      wrapper = mount(<Provider store={store}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store}>
+          <Article />
+        </Provider>,
+      );
     });
     test('should call onSelectedRating method instance', () => {
       wrapper.find('button[data-value="5"]').simulate('click');
@@ -101,7 +138,11 @@ describe('<Article />', () => {
     test('should call onSelectedRating method instance', () => {
       const state = { ...initialState, history: { push: jest.fn() } };
       store = mockStore(state);
-      wrapper = mount(<Provider store={store}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store}>
+          <Article />
+        </Provider>,
+      );
       wrapper.find('span[data-name="rate-btn"]').simulate('click');
       expect(wrapper.find('Article').props().history.push).toBeDefined();
     });
@@ -109,7 +150,11 @@ describe('<Article />', () => {
 
   describe('when clicking on share icon', () => {
     beforeEach(() => {
-      wrapper = mount(<Provider store={store}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store}>
+          <Article />
+        </Provider>,
+      );
     });
 
     test('should call on socialShare', () => {
@@ -132,7 +177,11 @@ describe('<Article />', () => {
     const state = initialState;
     state.article.singleArticle.cover = 'https://picsum.photos/200/300';
     store = mockStore(state);
-    wrapper = mount(<Provider store={store}><Article /></Provider>);
+    wrapper = mount(
+      <Provider store={store}>
+        <Article />
+      </Provider>,
+    );
     expect(wrapper.find('Article').props().singleArticle.cover).toBeDefined();
   });
 
@@ -140,7 +189,11 @@ describe('<Article />', () => {
     const state = initialState;
     state.article.singleArticle = articleDataDraft;
     store = mockStore(state);
-    wrapper = mount(<Provider store={store}><Article /></Provider>);
+    wrapper = mount(
+      <Provider store={store}>
+        <Article />
+      </Provider>,
+    );
     expect(wrapper.find('Article').props().singleArticle.tagList).toBeDefined();
   });
 
@@ -168,6 +221,7 @@ describe('<Article />', () => {
       mapDispatchToProps(dispatch).rateArticle({ articleSlug, rate: 3 });
       expect(dispatch).toHaveBeenCalled();
     });
+
     test('should call likeArticle action', () => {
       const articleSlug = 'article-slug';
       const dispatch = jest.fn();
@@ -199,16 +253,26 @@ describe('<Article />', () => {
         },
       };
       const store1 = mockStore(state);
-      wrapper = mount(<Provider store={store1}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store1}>
+          <Article />
+        </Provider>,
+      );
     });
 
     test('should like an article', () => {
-      wrapper.find('Article').find('button[data-value="like"]').simulate('click');
+      wrapper
+        .find('Article')
+        .find('button[data-value="like"]')
+        .simulate('click');
       expect(wrapper.find('Article').props().onLikeArticle).toBeDefined();
     });
 
     test('should dislike an article', () => {
-      wrapper.find('Article').find('button[data-value="dislike"]').simulate('click');
+      wrapper
+        .find('Article')
+        .find('button[data-value="dislike"]')
+        .simulate('click');
       expect(wrapper.find('Article').props().onDislikeArticle).toBeDefined();
     });
   });
@@ -227,25 +291,27 @@ describe('<Article />', () => {
         },
       };
       const store2 = mockStore(state);
-      wrapper = mount(<Provider store={store2}><Article /></Provider>);
+      wrapper = mount(
+        <Provider store={store2}>
+          <Article />
+        </Provider>,
+      );
     });
 
     test('should like an article', () => {
-      wrapper.find('Article').find('button[data-value="like"]').simulate('click');
+      wrapper
+        .find('Article')
+        .find('button[data-value="like"]')
+        .simulate('click');
       expect(wrapper.find('Article').props().nextPath).toBeDefined();
     });
 
     test('should dislike an article', () => {
-      wrapper.find('Article').find('button[data-value="dislike"]').simulate('click');
-      expect(wrapper.find('Article').props().nextPath).toBeDefined();
-    });
-
-    test('should call navigateToArticles instance function', () => {
       wrapper
-        .find('span[className="tagged"]')
-        .at(1)
+        .find('Article')
+        .find('button[data-value="dislike"]')
         .simulate('click');
-      expect(props.history.push).toHaveBeenCalled();
+      expect(wrapper.find('Article').props().nextPath).toBeDefined();
     });
   });
 });

--- a/src/__tests__/components/ConfirmedEmailEmail.test.js
+++ b/src/__tests__/components/ConfirmedEmailEmail.test.js
@@ -35,6 +35,7 @@ describe('<ConfirmedEmaiMessage  />', () => {
     wrapper = shallow(<ConfirmedEmailMessage {...props} />);
     expect(wrapper.state()).toEqual(defaultState);
   });
+
   test('should render default state', () => {
     wrapper = shallow(<ConfirmedEmailMessage {...props} />);
     wrapper.setState({ message: 'email confirmed' });

--- a/src/__tests__/helpers/editorPlugins/addLink.test.js
+++ b/src/__tests__/helpers/editorPlugins/addLink.test.js
@@ -10,6 +10,7 @@ describe('addLinkPlugin', () => {
     const { handleKeyCommand } = addLinkPlugin;
     expect(handleKeyCommand(command, editorState, { setEditorState })).toEqual('not-handled');
   });
+
   test('should handle key command', () => {
     const { handleKeyCommand } = addLinkPlugin;
     const command = 'add-link';
@@ -35,6 +36,7 @@ describe('addLinkPlugin', () => {
     const addLink = keyBindingFn(event, { getEditorState });
     expect(addLink).toEqual(undefined);
   });
+
   test('should return undefined', () => {
     const { keyBindingFn } = addLinkPlugin;
     const event = {

--- a/src/__tests__/helpers/mediaBlockRenderer.test.js
+++ b/src/__tests__/helpers/mediaBlockRenderer.test.js
@@ -12,6 +12,7 @@ describe('MediaBlockRender', () => {
     expect(component).toBeDefined();
     expect(editable).toBeFalsy();
   });
+
   test('should return null', () => {
     const block = {
       getType: () => '',
@@ -37,6 +38,7 @@ describe('Media', () => {
     const media = Media(props);
     expect(media).toEqual(<Image classes="article-img" src="image/hello.jpg" />);
   });
+
   test('should return a video component ', () => {
     const props = {
       contentState: {
@@ -52,6 +54,7 @@ describe('Media', () => {
     const media = Media(props);
     expect(media).toEqual(<Video classes="width-100" src="image/hello.mp4" />);
   });
+
   test('should return a video component ', () => {
     const props = {
       contentState: {

--- a/src/__tests__/reducers/articleReducer.test.js
+++ b/src/__tests__/reducers/articleReducer.test.js
@@ -105,19 +105,15 @@ describe('articleReducer', () => {
   });
 
   it('should handle `FETCHING_ALL_ARTICLE_SUCCESS`', () => {
-    const payload = [articleData];
+    const payload = { articlesList: [articleData] };
     const expectedState = {
       type: articleTypes.FETCHING_ALL_ARTICLE_SUCCESS,
       payload,
     };
     expect(reducer({}, expectedState)).toEqual({
-<<<<<<< HEAD
-      articles: payload,
+      ...payload,
       loading: false,
       success: true,
-=======
-      articles,
->>>>>>> feat(tags): rebase develop
     });
   });
 

--- a/src/__tests__/reducers/articleReducer.test.js
+++ b/src/__tests__/reducers/articleReducer.test.js
@@ -111,9 +111,13 @@ describe('articleReducer', () => {
       payload,
     };
     expect(reducer({}, expectedState)).toEqual({
+<<<<<<< HEAD
       articles: payload,
       loading: false,
       success: true,
+=======
+      articles,
+>>>>>>> feat(tags): rebase develop
     });
   });
 

--- a/src/_styles/pages/_Article.scss
+++ b/src/_styles/pages/_Article.scss
@@ -45,7 +45,7 @@
 }
 .article-date {
   margin: 20px 0;
-  font-size: 0.6rem;
+  font-size: 0.8rem;
   color: rgba(0, 0, 0, 0.3);
 }
 .article-side-actions {
@@ -74,15 +74,6 @@
       color: #e2c14a;
       a,
       i {
-        color: #e2c14a;
-      }
-    }
-    &.margin-top {
-      margin-top: 1.5rem;
-  .article-icon {
-    &.rated {
-      color: #e2c14a;
-      a {
         color: #e2c14a;
       }
     }
@@ -124,7 +115,6 @@
   }
 }
 .article-share {
-  margin: 10px 0;
   display: flex;
   align-items: center;
   flex-direction: row;
@@ -135,6 +125,9 @@
   button {
     background-color: transparent;
     font-size: 1rem;
+    i {
+      color: #717171;
+    }
   }
 }
 .tagged {
@@ -244,6 +237,11 @@
       display: inline-block;
       width: 100%;
     }
+    .box {
+      padding: 5px;
+      margin: 5px 0px;
+      border-radius: 0px;
+    }
   }
   .article-comment__center {
     margin: auto;
@@ -266,4 +264,45 @@
     color: $primary;
   }
 }
-
+.tooltip {
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 3px 6px;
+  position: absolute;
+  margin-top: -30px;
+  .higlight-btn {
+    background-color: black;
+  }
+  button {
+    background-color: black;
+    padding: 0;
+    i {
+      color: white;
+      font-size: 25px;
+    }
+  }
+}
+.hightlightedText {
+  background-color: yellow;
+  line-height: 1.5rem;
+  .comment-trigger {
+    position: absolute;
+    right: 0;
+    padding-right: 30px;
+  }
+}
+.comment-wrapper {
+  width: 50%;
+  position: absolute;
+  border-radius: 15px;
+  padding: 10px 0px 10px 10px;
+  font-family: Roboto-light;
+  resize: none;
+  &:focus {
+    outline: none;
+    border-color: $primary;
+    border-width: 2px;
+  }
+}

--- a/src/components/Article/Article.jsx
+++ b/src/components/Article/Article.jsx
@@ -100,6 +100,28 @@ export class Article extends Component {
     rateArticle({ articleSlug: slug, rate: value });
   };
 
+  navigateToArticles = (e) => {
+    const { history } = this.props;
+    history.push(`/articles?page1&tag=${e.target.dataset.value}`);
+  };
+
+  renderTags = () => {
+    const {
+      singleArticle: { tagList },
+    } = this.props;
+    return (
+      <div className="row">
+        <div className="col-12 content-center">
+          {tagList.map(tag => (
+            <span key={tag} className="tagged" data-value={tag} onClick={this.navigateToArticles}>
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
   renderCover = () => {
     const {
       singleArticle: { cover },
@@ -156,38 +178,7 @@ export class Article extends Component {
     }
     e.preventDefault();
   };
-
-  SocialShare = (on) => {
-    const {
-      onShare,
-      article: { slug },
-    } = this.props;
-
-    onShare({ on, articleSlug: slug });
-  };
   
-  navigateToArticles = e => {
-    const { history } = this.props;
-    history.push(`/articles?page1&tag=${e.target.dataset.value}`);
-  };
-
-  renderTags = () => {
-    const {
-      article: { tagList },
-    } = this.props;
-    return (
-      <div className="row">
-        <div className="col-12 content-center">
-          {tagList.map(tag => (
-            <span key={tag} className="tagged" data-value={tag} onClick={this.navigateToArticles}>
-              {tag}
-            </span>
-          ))}
-        </div>
-      </div>
-    );
-  };
-
   render() {
     const {
       singleArticle,

--- a/src/components/Article/Article.jsx
+++ b/src/components/Article/Article.jsx
@@ -30,8 +30,6 @@ export class Article extends Component {
       },
       getArticle,
     } = this.props;
-
-    console.log(this.props);
     getArticle(articleSlug);
   }
 

--- a/src/components/Article/Article.jsx
+++ b/src/components/Article/Article.jsx
@@ -178,14 +178,19 @@ export class Article extends Component {
     }
     e.preventDefault();
   };
-  
+
+  SocialShare = (on) => {
+    const {
+      onShare,
+      article: { slug },
+    } = this.props;
+
+    onShare({ on, articleSlug: slug });
+  };
+
   render() {
     const {
-      singleArticle,
-      liked, disliked,
-      likeCount,
-      dislikeCount,
-      history,
+      singleArticle, liked, disliked, likeCount, dislikeCount, history,
     } = this.props;
     return (
       <section className="main-content">

--- a/src/components/Article/Article.jsx
+++ b/src/components/Article/Article.jsx
@@ -30,6 +30,8 @@ export class Article extends Component {
       },
       getArticle,
     } = this.props;
+
+    console.log(this.props);
     getArticle(articleSlug);
   }
 
@@ -100,23 +102,6 @@ export class Article extends Component {
     rateArticle({ articleSlug: slug, rate: value });
   };
 
-  renderTags = () => {
-    const {
-      singleArticle: { tagList },
-    } = this.props;
-    return (
-      <div className="row">
-        <div className="col-12 content-center">
-          {tagList.map(tag => (
-            <span key={tag} className="tagged">
-              {tag}
-            </span>
-          ))}
-        </div>
-      </div>
-    );
-  };
-
   renderCover = () => {
     const {
       singleArticle: { cover },
@@ -181,6 +166,28 @@ export class Article extends Component {
     } = this.props;
 
     onShare({ on, articleSlug: slug });
+  };
+  
+  navigateToArticles = e => {
+    const { history } = this.props;
+    history.push(`/articles?page1&tag=${e.target.dataset.value}`);
+  };
+
+  renderTags = () => {
+    const {
+      article: { tagList },
+    } = this.props;
+    return (
+      <div className="row">
+        <div className="col-12 content-center">
+          {tagList.map(tag => (
+            <span key={tag} className="tagged" data-value={tag} onClick={this.navigateToArticles}>
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    );
   };
 
   render() {

--- a/src/redux/reducers/articleReducer.js
+++ b/src/redux/reducers/articleReducer.js
@@ -64,10 +64,7 @@ const articleReducer = (state = initialState, { type, payload }) => {
     case articleTypes.FETCHING_ALL_ARTICLE_SUCCESS:
       return {
         ...state,
-        articles: payload,
-        articlesList: payload.articles,
-        loading: false,
-        success: true,
+        ...payload,
       };
     case articleTypes.FETCHING_ALL_ARTICLE_FAILURE:
       return {

--- a/src/redux/reducers/articleReducer.js
+++ b/src/redux/reducers/articleReducer.js
@@ -65,6 +65,8 @@ const articleReducer = (state = initialState, { type, payload }) => {
       return {
         ...state,
         ...payload,
+        loading: false,
+        success: true,
       };
     case articleTypes.FETCHING_ALL_ARTICLE_FAILURE:
       return {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,4 +51,7 @@ module.exports = {
     hot: true,
     historyApiFallback: true,
   },
+  node: {
+    fs: 'empty',
+  },
 };


### PR DESCRIPTION
#### What does this PR do?
Implement filter by tags when viewing an article

#### Description of Task to be completed?
- add tests
- add filter by tags in view article components

#### How should this be manually tested?
- git clone
- npm install
- npm run start
- Navigate to articles`base_url/articles`
- Click on any article presented
- In view one article click on any `Tag` to go to articles with similar tag

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
`#163519108`

#### Screenshots

#### Questions:
